### PR TITLE
feat: add k8s-job helm chart

### DIFF
--- a/charts/k8s-job/Chart.yaml
+++ b/charts/k8s-job/Chart.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v2
+name: k8s-job
+description: A Helm chart to deploy generic Kubernetes jobs with configurable RBAC
+type: application
+version: 0.1.0
+appVersion: "0.1.0"

--- a/charts/k8s-job/Chart.yaml
+++ b/charts/k8s-job/Chart.yaml
@@ -5,3 +5,13 @@ description: A Helm chart to deploy generic Kubernetes jobs with configurable RB
 type: application
 version: 0.1.0
 appVersion: "0.1.0"
+
+home: https://github.com/pltf-dev/helm-charts
+# icon: https://.svg
+keywords:
+  - k8s-jobs
+  - jobs
+
+maintainers:
+  - name: marcel-dias
+    email: marcel@pltf.dev

--- a/charts/k8s-job/README.md
+++ b/charts/k8s-job/README.md
@@ -1,0 +1,260 @@
+# k8s-job Helm Chart
+
+A generic Helm chart for deploying Kubernetes Jobs with configurable RBAC, service accounts, and ArgoCD integration.
+
+## Key Features
+
+- **Multiple Jobs**: Define multiple jobs in a single release via the `jobs` map
+- **Defaults + Overrides**: Global `jobDefaults` with per-job override capability
+- **RBAC Support**: Optional Role/ClusterRole and RoleBinding/ClusterRoleBinding per job
+- **External Secrets**: Integration with External Secrets Operator using dataFrom with regex
+- **ArgoCD Integration**: Pre-configured hooks and sync waves for GitOps workflows
+- **AWS IRSA**: Service account annotations for IAM Roles for Service Accounts
+- **Flexible Configuration**: Support for env vars, secrets, volumes, resources, and scheduling
+
+## Quick Start
+
+### Minimum Values
+
+```yaml
+jobs:
+  my-job:
+    enabled: true
+    command: ["echo"]
+    args: ["Hello, World!"]
+```
+
+### Deploy a Lambda Function
+
+```yaml
+jobs:
+  deploy-lambda:
+    enabled: true
+    image:
+      repository: node
+      tag: "20-alpine"
+    command: ["npm"]
+    args: ["run", "deploy:prod"]
+    serviceAccount:
+      annotations:
+        eks.amazonaws.com/role-arn: arn:aws:iam::123456789:role/lambda-deploy
+```
+
+### Job with RBAC
+
+```yaml
+jobs:
+  k8s-task:
+    enabled: true
+    image:
+      repository: alpine/k8s
+      tag: "1.34.1"
+    command: ["/bin/sh", "-c"]
+    args: ["kubectl get configmaps"]
+    rbac:
+      create: true
+      rules:
+        - apiGroups: [""]
+          resources: ["configmaps"]
+          verbs: ["get", "list"]
+```
+
+### Job with ClusterRole
+
+```yaml
+jobs:
+  cluster-task:
+    enabled: true
+    image:
+      repository: alpine/k8s
+      tag: "1.34.1"
+    command: ["/bin/sh", "-c"]
+    args: ["kubectl get nodes"]
+    rbac:
+      create: true
+      clusterScope: true
+      rules:
+        - apiGroups: [""]
+          resources: ["nodes"]
+          verbs: ["get", "list"]
+```
+
+### Job with External Secrets
+
+```yaml
+jobs:
+  deploy-lambda:
+    enabled: true
+    command: ["npm"]
+    args: ["run", "deploy:prod"]
+    envFrom:
+      - secretRef:
+          name: lambda-secrets
+    externalSecret:
+      enabled: true
+      name: lambda-secrets
+      dataFrom:
+        path: /cf2/production/lambda/
+        regexp: ".*"
+        rewrite:
+          source: "/cf2/production/lambda/(.*)"
+          target: "$1"
+```
+
+## Configuration
+
+### Global Defaults (`jobDefaults`)
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `image.repository` | Default container image | `node` |
+| `image.tag` | Default image tag | `20-alpine` |
+| `image.pullPolicy` | Image pull policy | `IfNotPresent` |
+| `ttlSecondsAfterFinished` | Job cleanup time | `600` |
+| `backoffLimit` | Job retry limit | `1` |
+| `completions` | Number of completions | `1` |
+| `parallelism` | Parallel pod count | `1` |
+| `resources.limits.cpu` | CPU limit | `500m` |
+| `resources.limits.memory` | Memory limit | `256Mi` |
+| `resources.requests.cpu` | CPU request | `100m` |
+| `resources.requests.memory` | Memory request | `128Mi` |
+
+### Per-Job Configuration
+
+Each job under `jobs.<name>` can override any default and supports:
+
+| Parameter | Description |
+|-----------|-------------|
+| `enabled` | Enable/disable the job |
+| `image.repository` | Container image |
+| `image.tag` | Image tag |
+| `command` | Container command (entrypoint) |
+| `args` | Container arguments |
+| `workingDir` | Working directory |
+| `env` | Environment variables list |
+| `envFrom` | Environment from secrets/configmaps |
+| `resources` | CPU/memory limits and requests |
+| `volumes` | Volume definitions |
+| `volumeMounts` | Volume mount paths |
+| `nodeSelector` | Node selection constraints |
+| `tolerations` | Pod tolerations |
+| `affinity` | Pod affinity rules |
+| `podSecurityContext` | Pod-level security context |
+| `securityContext` | Container-level security context |
+
+### Service Account Configuration
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `serviceAccount.create` | Create service account | `true` |
+| `serviceAccount.annotations` | SA annotations (e.g., IRSA) | `{}` |
+
+### RBAC Configuration
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `rbac.create` | Create RBAC resources | `false` |
+| `rbac.clusterScope` | Use ClusterRole instead of Role | `false` |
+| `rbac.rules` | RBAC rules list | `[]` |
+
+### ArgoCD Configuration
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `argocd.hook` | ArgoCD hook type | `PreSync` |
+| `argocd.syncWave` | Sync wave for job | `1` |
+| `argocd.hookDeletePolicy` | Hook delete policy | `BeforeHookCreation` |
+
+### External Secrets Configuration
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `externalSecret.enabled` | Enable ExternalSecret creation | `false` |
+| `externalSecret.name` | Secret name (defaults to job fullname) | `""` |
+| `externalSecret.refreshInterval` | How often to sync secrets | `"0"` |
+| `externalSecret.refreshPolicy` | When to refresh secrets (OnChange, Always) | `OnChange` |
+| `externalSecret.secretStoreRef.name` | SecretStore name | `aws-parameter-store-cluster` |
+| `externalSecret.secretStoreRef.kind` | SecretStore kind | `ClusterSecretStore` |
+| `externalSecret.creationPolicy` | Secret creation policy | `Owner` |
+| `externalSecret.deletionPolicy` | Secret deletion policy | `Retain` |
+| `externalSecret.dataFrom.path` | Parameter store path prefix | `""` |
+| `externalSecret.dataFrom.regexp` | Regex pattern for matching secrets | `""` |
+| `externalSecret.dataFrom.rewrite.source` | Regex source pattern for key rewriting | `""` |
+| `externalSecret.dataFrom.rewrite.target` | Replacement pattern for key rewriting | `""` |
+
+## ArgoCD Sync Waves
+
+Resources are created in the following order:
+
+1. **Wave -1**: ExternalSecret (ensures secrets are available before job runs)
+2. **Wave 0**: ServiceAccount, Role/ClusterRole, RoleBinding/ClusterRoleBinding
+3. **Wave 1**: Job (default, configurable per job)
+
+## Full Example
+
+```yaml
+jobDefaults:
+  resources:
+    limits:
+      cpu: "1"
+      memory: 512Mi
+    requests:
+      cpu: 250m
+      memory: 256Mi
+
+jobs:
+  deploy-lambda-prod:
+    enabled: true
+    image:
+      repository: node
+      tag: "20-alpine"
+    command: ["npm"]
+    args: ["run", "deploy:prod"]
+    workingDir: /app
+    env:
+      - name: NODE_ENV
+        value: production
+      - name: AWS_REGION
+        value: us-east-1
+    envFrom:
+      - secretRef:
+          name: lambda-secrets
+    serviceAccount:
+      annotations:
+        eks.amazonaws.com/role-arn: arn:aws:iam::123456789:role/lambda-deploy
+    resources:
+      limits:
+        cpu: "2"
+        memory: 1Gi
+    argocd:
+      hook: PostSync
+      syncWave: "2"
+
+  notify-slack:
+    enabled: true
+    image:
+      repository: curlimages/curl
+      tag: "8.5.0"
+    command: ["/bin/sh", "-c"]
+    args:
+      - |
+        curl -X POST $SLACK_WEBHOOK_URL -d '{"text":"Deployment complete!"}'
+    envFrom:
+      - secretRef:
+          name: slack-webhook
+    argocd:
+      hook: PostSync
+      syncWave: "3"
+```
+
+## Installation
+
+```bash
+helm install my-jobs charts/k8s-job -f values.yaml
+```
+
+## Template Validation
+
+```bash
+helm template my-jobs charts/k8s-job -f values.yaml
+```

--- a/charts/k8s-job/templates/_helpers.tpl
+++ b/charts/k8s-job/templates/_helpers.tpl
@@ -1,0 +1,178 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "k8s-job.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "k8s-job.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "k8s-job.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "k8s-job.labels" -}}
+helm.sh/chart: {{ include "k8s-job.chart" . }}
+{{ include "k8s-job.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "k8s-job.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "k8s-job.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Job-specific labels (includes job name component)
+*/}}
+{{- define "k8s-job.jobLabels" -}}
+{{ include "k8s-job.labels" . }}
+app.kubernetes.io/component: {{ .jobName }}
+{{- end }}
+
+{{/*
+Create job full name (release-jobname)
+*/}}
+{{- define "k8s-job.jobFullname" -}}
+{{- $baseName := include "k8s-job.fullname" .root }}
+{{- printf "%s-%s" $baseName .jobName | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Merge job config with defaults
+Returns the merged configuration for a specific job
+Usage: {{ include "k8s-job.mergeJobConfig" (dict "root" . "jobName" $jobName "jobConfig" $jobConfig) }}
+*/}}
+{{- define "k8s-job.mergeJobConfig" -}}
+{{- $defaults := .root.Values.jobDefaults }}
+{{- $job := .jobConfig }}
+{{- $merged := dict }}
+
+{{/* Merge image */}}
+{{- $defaultImage := $defaults.image | default dict }}
+{{- $jobImage := $job.image | default dict }}
+{{- $_ := set $merged "image" (merge $jobImage $defaultImage) }}
+
+{{/* Merge simple values with defaults */}}
+{{- $_ := set $merged "ttlSecondsAfterFinished" ($job.ttlSecondsAfterFinished | default $defaults.ttlSecondsAfterFinished) }}
+{{- $_ := set $merged "backoffLimit" ($job.backoffLimit | default $defaults.backoffLimit) }}
+{{- $_ := set $merged "completions" ($job.completions | default $defaults.completions) }}
+{{- $_ := set $merged "parallelism" ($job.parallelism | default $defaults.parallelism) }}
+
+{{/* Merge argocd config */}}
+{{- $defaultArgocd := $defaults.argocd | default dict }}
+{{- $jobArgocd := $job.argocd | default dict }}
+{{- $_ := set $merged "argocd" (merge $jobArgocd $defaultArgocd) }}
+
+{{/* Merge container config */}}
+{{- $_ := set $merged "command" ($job.command | default $defaults.command) }}
+{{- $_ := set $merged "args" ($job.args | default $defaults.args) }}
+{{- $_ := set $merged "workingDir" ($job.workingDir | default $defaults.workingDir) }}
+{{- $_ := set $merged "env" ($job.env | default $defaults.env) }}
+{{- $_ := set $merged "envFrom" ($job.envFrom | default $defaults.envFrom) }}
+
+{{/* Merge resources */}}
+{{- $defaultResources := $defaults.resources | default dict }}
+{{- $jobResources := $job.resources | default dict }}
+{{- $_ := set $merged "resources" (merge $jobResources $defaultResources) }}
+
+{{/* Merge security contexts */}}
+{{- $_ := set $merged "podSecurityContext" ($job.podSecurityContext | default $defaults.podSecurityContext) }}
+{{- $_ := set $merged "securityContext" ($job.securityContext | default $defaults.securityContext) }}
+
+{{/* Merge scheduling */}}
+{{- $_ := set $merged "nodeSelector" ($job.nodeSelector | default $defaults.nodeSelector) }}
+{{- $_ := set $merged "tolerations" ($job.tolerations | default $defaults.tolerations) }}
+{{- $_ := set $merged "affinity" ($job.affinity | default $defaults.affinity) }}
+
+{{/* Merge volumes */}}
+{{- $_ := set $merged "volumes" ($job.volumes | default $defaults.volumes) }}
+{{- $_ := set $merged "volumeMounts" ($job.volumeMounts | default $defaults.volumeMounts) }}
+
+{{/* Merge serviceAccount - check job-level create first, then default */}}
+{{- $defaultSA := $defaults.serviceAccount | default dict }}
+{{- $jobSA := $job.serviceAccount | default dict }}
+{{- $mergedSA := dict }}
+{{- $_ := set $mergedSA "annotations" ($jobSA.annotations | default $defaultSA.annotations | default dict) }}
+{{/* For create, check if explicitly set in the original jobConfig (before any helm merging) */}}
+{{- $saCreate := $defaultSA.create }}
+{{- if hasKey $jobSA "create" }}
+{{- $saCreate = $jobSA.create }}
+{{- end }}
+{{- $_ := set $mergedSA "create" $saCreate }}
+{{- $_ := set $merged "serviceAccount" $mergedSA }}
+
+{{/* Merge RBAC - handle boolean fields explicitly */}}
+{{- $defaultRbac := $defaults.rbac | default dict }}
+{{- $jobRbac := $job.rbac | default dict }}
+{{- $mergedRbac := merge $jobRbac $defaultRbac }}
+{{- if hasKey $jobRbac "create" }}
+{{- $_ := set $mergedRbac "create" $jobRbac.create }}
+{{- end }}
+{{- if hasKey $jobRbac "clusterScope" }}
+{{- $_ := set $mergedRbac "clusterScope" $jobRbac.clusterScope }}
+{{- end }}
+{{- $_ := set $merged "rbac" $mergedRbac }}
+
+{{/* Merge externalSecret - handle boolean enabled field explicitly */}}
+{{- $defaultES := $defaults.externalSecret | default dict }}
+{{- $jobES := $job.externalSecret | default dict }}
+{{- $mergedES := dict }}
+{{/* Handle enabled boolean */}}
+{{- $esEnabled := $defaultES.enabled }}
+{{- if hasKey $jobES "enabled" }}
+{{- $esEnabled = $jobES.enabled }}
+{{- end }}
+{{- $_ := set $mergedES "enabled" $esEnabled }}
+{{/* Merge other fields */}}
+{{- $_ := set $mergedES "name" ($jobES.name | default $defaultES.name) }}
+{{- $_ := set $mergedES "refreshInterval" ($jobES.refreshInterval | default $defaultES.refreshInterval) }}
+{{- $_ := set $mergedES "refreshPolicy" ($jobES.refreshPolicy | default $defaultES.refreshPolicy) }}
+{{- $_ := set $mergedES "creationPolicy" ($jobES.creationPolicy | default $defaultES.creationPolicy) }}
+{{- $_ := set $mergedES "deletionPolicy" ($jobES.deletionPolicy | default $defaultES.deletionPolicy) }}
+{{/* Merge secretStoreRef */}}
+{{- $defaultStoreRef := $defaultES.secretStoreRef | default dict }}
+{{- $jobStoreRef := $jobES.secretStoreRef | default dict }}
+{{- $_ := set $mergedES "secretStoreRef" (merge $jobStoreRef $defaultStoreRef) }}
+{{/* Merge dataFrom */}}
+{{- $defaultDataFrom := $defaultES.dataFrom | default dict }}
+{{- $jobDataFrom := $jobES.dataFrom | default dict }}
+{{- $mergedDataFrom := dict }}
+{{- $_ := set $mergedDataFrom "path" ($jobDataFrom.path | default $defaultDataFrom.path) }}
+{{- $_ := set $mergedDataFrom "regexp" ($jobDataFrom.regexp | default $defaultDataFrom.regexp) }}
+{{- $defaultRewrite := $defaultDataFrom.rewrite | default dict }}
+{{- $jobRewrite := $jobDataFrom.rewrite | default dict }}
+{{- $_ := set $mergedDataFrom "rewrite" (merge $jobRewrite $defaultRewrite) }}
+{{- $_ := set $mergedES "dataFrom" $mergedDataFrom }}
+{{- $_ := set $merged "externalSecret" $mergedES }}
+
+{{- $merged | toJson }}
+{{- end }}

--- a/charts/k8s-job/templates/external-secrets.yaml
+++ b/charts/k8s-job/templates/external-secrets.yaml
@@ -1,0 +1,43 @@
+{{- range $jobName, $jobConfig := .Values.jobs }}
+{{- if $jobConfig.enabled }}
+{{- $mergedJson := include "k8s-job.mergeJobConfig" (dict "root" $ "jobName" $jobName "jobConfig" $jobConfig) }}
+{{- $merged := $mergedJson | fromJson }}
+{{- if $merged.externalSecret.enabled }}
+{{- $fullname := include "k8s-job.jobFullname" (dict "root" $ "jobName" $jobName) }}
+{{- $es := $merged.externalSecret }}
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: {{ $es.name | default $fullname }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+  labels:
+    {{- include "k8s-job.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: {{ $jobName }}
+spec:
+  refreshInterval: {{ $es.refreshInterval | default "0" | quote }}
+  refreshPolicy: {{ $es.refreshPolicy | default "OnChange" }}
+  secretStoreRef:
+    name: {{ $es.secretStoreRef.name | default "aws-parameter-store-cluster" }}
+    kind: {{ $es.secretStoreRef.kind | default "ClusterSecretStore" }}
+  target:
+    name: {{ $es.name | default $fullname }}
+    creationPolicy: {{ $es.creationPolicy | default "Owner" }}
+    deletionPolicy: {{ $es.deletionPolicy | default "Retain" }}
+  dataFrom:
+    - find:
+        {{- if $es.dataFrom.path }}
+        path: {{ $es.dataFrom.path }}
+        {{- end }}
+        name:
+          regexp: {{ $es.dataFrom.regexp | quote }}
+      {{- if $es.dataFrom.rewrite }}
+      rewrite:
+        - regexp:
+            source: {{ $es.dataFrom.rewrite.source | quote }}
+            target: {{ $es.dataFrom.rewrite.target | quote }}
+      {{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/k8s-job/templates/job.yaml
+++ b/charts/k8s-job/templates/job.yaml
@@ -1,0 +1,93 @@
+{{- range $jobName, $jobConfig := .Values.jobs }}
+{{- if $jobConfig.enabled }}
+{{- $mergedJson := include "k8s-job.mergeJobConfig" (dict "root" $ "jobName" $jobName "jobConfig" $jobConfig) }}
+{{- $merged := $mergedJson | fromJson }}
+{{- $fullname := include "k8s-job.jobFullname" (dict "root" $ "jobName" $jobName) }}
+{{- $image := printf "%s:%s" $merged.image.repository $merged.image.tag }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ $fullname }}
+  annotations:
+    argocd.argoproj.io/sync-options: Replace=true
+    argocd.argoproj.io/hook: {{ $merged.argocd.hook }}
+    argocd.argoproj.io/sync-wave: {{ $merged.argocd.syncWave | quote }}
+    argocd.argoproj.io/hook-delete-policy: {{ $merged.argocd.hookDeletePolicy }}
+  labels:
+    {{- include "k8s-job.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: {{ $jobName }}
+spec:
+  ttlSecondsAfterFinished: {{ $merged.ttlSecondsAfterFinished }}
+  backoffLimit: {{ $merged.backoffLimit }}
+  completions: {{ $merged.completions }}
+  parallelism: {{ $merged.parallelism }}
+  template:
+    metadata:
+      labels:
+        {{- include "k8s-job.selectorLabels" $ | nindent 8 }}
+        app.kubernetes.io/component: {{ $jobName }}
+    spec:
+      restartPolicy: Never
+      serviceAccountName: {{ $fullname }}
+      {{- with $merged.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $.Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $merged.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $merged.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $merged.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $merged.volumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ $jobName }}
+          image: {{ $image | quote }}
+          imagePullPolicy: {{ $merged.image.pullPolicy | default "IfNotPresent" }}
+          {{- with $merged.workingDir }}
+          workingDir: {{ . }}
+          {{- end }}
+          {{- with $merged.command }}
+          command:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with $merged.args }}
+          args:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with $merged.env }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with $merged.envFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with $merged.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with $merged.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with $merged.volumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/k8s-job/templates/role.yaml
+++ b/charts/k8s-job/templates/role.yaml
@@ -1,0 +1,37 @@
+{{- range $jobName, $jobConfig := .Values.jobs }}
+{{- if $jobConfig.enabled }}
+{{- $mergedJson := include "k8s-job.mergeJobConfig" (dict "root" $ "jobName" $jobName "jobConfig" $jobConfig) }}
+{{- $merged := $mergedJson | fromJson }}
+{{- if and $merged.rbac.create $merged.rbac.rules }}
+{{- $fullname := include "k8s-job.jobFullname" (dict "root" $ "jobName" $jobName) }}
+---
+{{- if $merged.rbac.clusterScope }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ $fullname }}
+  annotations:
+    argocd.argoproj.io/hook: {{ $merged.argocd.hook }}
+    argocd.argoproj.io/sync-wave: "0"
+  labels:
+    {{- include "k8s-job.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: {{ $jobName }}
+rules:
+  {{- toYaml $merged.rbac.rules | nindent 2 }}
+{{- else }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ $fullname }}
+  annotations:
+    argocd.argoproj.io/hook: {{ $merged.argocd.hook }}
+    argocd.argoproj.io/sync-wave: "0"
+  labels:
+    {{- include "k8s-job.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: {{ $jobName }}
+rules:
+  {{- toYaml $merged.rbac.rules | nindent 2 }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/k8s-job/templates/rolebinding.yaml
+++ b/charts/k8s-job/templates/rolebinding.yaml
@@ -1,0 +1,48 @@
+{{- range $jobName, $jobConfig := .Values.jobs }}
+{{- if $jobConfig.enabled }}
+{{- $mergedJson := include "k8s-job.mergeJobConfig" (dict "root" $ "jobName" $jobName "jobConfig" $jobConfig) }}
+{{- $merged := $mergedJson | fromJson }}
+{{- if and $merged.rbac.create $merged.rbac.rules }}
+{{- $fullname := include "k8s-job.jobFullname" (dict "root" $ "jobName" $jobName) }}
+---
+{{- if $merged.rbac.clusterScope }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ $fullname }}
+  annotations:
+    argocd.argoproj.io/hook: {{ $merged.argocd.hook }}
+    argocd.argoproj.io/sync-wave: "0"
+  labels:
+    {{- include "k8s-job.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: {{ $jobName }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ $fullname }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ $fullname }}
+    namespace: {{ $.Release.Namespace }}
+{{- else }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ $fullname }}
+  annotations:
+    argocd.argoproj.io/hook: {{ $merged.argocd.hook }}
+    argocd.argoproj.io/sync-wave: "0"
+  labels:
+    {{- include "k8s-job.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: {{ $jobName }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ $fullname }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ $fullname }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/k8s-job/templates/serviceaccount.yaml
+++ b/charts/k8s-job/templates/serviceaccount.yaml
@@ -1,0 +1,23 @@
+{{- range $jobName, $jobConfig := .Values.jobs }}
+{{- if $jobConfig.enabled }}
+{{- $mergedJson := include "k8s-job.mergeJobConfig" (dict "root" $ "jobName" $jobName "jobConfig" $jobConfig) }}
+{{- $merged := $mergedJson | fromJson }}
+{{- if ne (toString $merged.serviceAccount.create) "false" }}
+{{- $fullname := include "k8s-job.jobFullname" (dict "root" $ "jobName" $jobName) }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ $fullname }}
+  annotations:
+    argocd.argoproj.io/hook: {{ $merged.argocd.hook }}
+    argocd.argoproj.io/sync-wave: "0"
+    {{- with $merged.serviceAccount.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  labels:
+    {{- include "k8s-job.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: {{ $jobName }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/k8s-job/tests/external-secrets_test.yaml
+++ b/charts/k8s-job/tests/external-secrets_test.yaml
@@ -1,0 +1,339 @@
+suite: external-secrets tests
+templates:
+  - external-secrets.yaml
+tests:
+  - it: should not render when no jobs are defined
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not render when job is disabled
+    set:
+      jobs:
+        my-job:
+          enabled: false
+          externalSecret:
+            enabled: true
+            dataFrom:
+              regexp: ".*"
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not render when externalSecret is disabled
+    set:
+      jobs:
+        my-job:
+          enabled: true
+          command: ["echo"]
+          args: ["hello"]
+          externalSecret:
+            enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not render when externalSecret is not configured
+    set:
+      jobs:
+        my-job:
+          enabled: true
+          command: ["echo"]
+          args: ["hello"]
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render ExternalSecret when enabled with regexp
+    set:
+      jobs:
+        my-job:
+          enabled: true
+          command: ["echo"]
+          args: ["hello"]
+          externalSecret:
+            enabled: true
+            dataFrom:
+              regexp: "/cf2/production/.*"
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ExternalSecret
+
+  - it: should set correct ExternalSecret name from job fullname
+    release:
+      name: test-release
+    set:
+      jobs:
+        deploy-lambda:
+          enabled: true
+          command: ["npm"]
+          args: ["deploy"]
+          externalSecret:
+            enabled: true
+            dataFrom:
+              regexp: ".*"
+    asserts:
+      - equal:
+          path: metadata.name
+          value: test-release-k8s-job-deploy-lambda
+      - equal:
+          path: spec.target.name
+          value: test-release-k8s-job-deploy-lambda
+
+  - it: should allow custom ExternalSecret name
+    release:
+      name: test-release
+    set:
+      jobs:
+        my-job:
+          enabled: true
+          command: ["echo"]
+          args: ["hello"]
+          externalSecret:
+            enabled: true
+            name: custom-secret-name
+            dataFrom:
+              regexp: ".*"
+    asserts:
+      - equal:
+          path: metadata.name
+          value: custom-secret-name
+      - equal:
+          path: spec.target.name
+          value: custom-secret-name
+
+  - it: should use default secretStoreRef
+    set:
+      jobs:
+        my-job:
+          enabled: true
+          command: ["echo"]
+          args: ["hello"]
+          externalSecret:
+            enabled: true
+            dataFrom:
+              regexp: ".*"
+    asserts:
+      - equal:
+          path: spec.secretStoreRef.name
+          value: aws-parameter-store-cluster
+      - equal:
+          path: spec.secretStoreRef.kind
+          value: ClusterSecretStore
+
+  - it: should allow custom secretStoreRef
+    set:
+      jobs:
+        my-job:
+          enabled: true
+          command: ["echo"]
+          args: ["hello"]
+          externalSecret:
+            enabled: true
+            secretStoreRef:
+              name: custom-secret-store
+              kind: SecretStore
+            dataFrom:
+              regexp: ".*"
+    asserts:
+      - equal:
+          path: spec.secretStoreRef.name
+          value: custom-secret-store
+      - equal:
+          path: spec.secretStoreRef.kind
+          value: SecretStore
+
+  - it: should set default policies
+    set:
+      jobs:
+        my-job:
+          enabled: true
+          command: ["echo"]
+          args: ["hello"]
+          externalSecret:
+            enabled: true
+            dataFrom:
+              regexp: ".*"
+    asserts:
+      - equal:
+          path: spec.target.creationPolicy
+          value: Owner
+      - equal:
+          path: spec.target.deletionPolicy
+          value: Retain
+      - equal:
+          path: spec.refreshInterval
+          value: "0"
+      - equal:
+          path: spec.refreshPolicy
+          value: OnChange
+
+  - it: should allow custom policies
+    set:
+      jobs:
+        my-job:
+          enabled: true
+          command: ["echo"]
+          args: ["hello"]
+          externalSecret:
+            enabled: true
+            refreshInterval: "1h"
+            refreshPolicy: Always
+            creationPolicy: Merge
+            deletionPolicy: Delete
+            dataFrom:
+              regexp: ".*"
+    asserts:
+      - equal:
+          path: spec.refreshInterval
+          value: "1h"
+      - equal:
+          path: spec.refreshPolicy
+          value: Always
+      - equal:
+          path: spec.target.creationPolicy
+          value: Merge
+      - equal:
+          path: spec.target.deletionPolicy
+          value: Delete
+
+  - it: should set dataFrom with regexp only
+    set:
+      jobs:
+        my-job:
+          enabled: true
+          command: ["echo"]
+          args: ["hello"]
+          externalSecret:
+            enabled: true
+            dataFrom:
+              regexp: "/cf2/production/lambda/.*"
+    asserts:
+      - equal:
+          path: spec.dataFrom[0].find.name.regexp
+          value: "/cf2/production/lambda/.*"
+      - isNull:
+          path: spec.dataFrom[0].find.path
+
+  - it: should set dataFrom with path and regexp
+    set:
+      jobs:
+        my-job:
+          enabled: true
+          command: ["echo"]
+          args: ["hello"]
+          externalSecret:
+            enabled: true
+            dataFrom:
+              path: /cf2/production/lambda/
+              regexp: ".*"
+    asserts:
+      - equal:
+          path: spec.dataFrom[0].find.path
+          value: /cf2/production/lambda/
+      - equal:
+          path: spec.dataFrom[0].find.name.regexp
+          value: ".*"
+
+  - it: should set dataFrom with rewrite
+    set:
+      jobs:
+        my-job:
+          enabled: true
+          command: ["echo"]
+          args: ["hello"]
+          externalSecret:
+            enabled: true
+            dataFrom:
+              path: /cf2/production/lambda/
+              regexp: ".*"
+              rewrite:
+                source: "/cf2/production/lambda/(.*)"
+                target: "$1"
+    asserts:
+      - equal:
+          path: spec.dataFrom[0].rewrite[0].regexp.source
+          value: "/cf2/production/lambda/(.*)"
+      - equal:
+          path: spec.dataFrom[0].rewrite[0].regexp.target
+          value: "$1"
+
+  - it: should not include rewrite when not configured
+    set:
+      jobs:
+        my-job:
+          enabled: true
+          command: ["echo"]
+          args: ["hello"]
+          externalSecret:
+            enabled: true
+            dataFrom:
+              regexp: ".*"
+    asserts:
+      - isNull:
+          path: spec.dataFrom[0].rewrite
+
+  - it: should set ArgoCD sync-wave annotation
+    set:
+      jobs:
+        my-job:
+          enabled: true
+          command: ["echo"]
+          args: ["hello"]
+          externalSecret:
+            enabled: true
+            dataFrom:
+              regexp: ".*"
+    asserts:
+      - equal:
+          path: metadata.annotations["argocd.argoproj.io/sync-wave"]
+          value: "-1"
+
+  - it: should have correct labels
+    release:
+      name: test-release
+    set:
+      jobs:
+        my-job:
+          enabled: true
+          command: ["echo"]
+          args: ["hello"]
+          externalSecret:
+            enabled: true
+            dataFrom:
+              regexp: ".*"
+    asserts:
+      - equal:
+          path: metadata.labels["app.kubernetes.io/name"]
+          value: k8s-job
+      - equal:
+          path: metadata.labels["app.kubernetes.io/instance"]
+          value: test-release
+      - equal:
+          path: metadata.labels["app.kubernetes.io/component"]
+          value: my-job
+
+  - it: should render multiple ExternalSecrets for multiple jobs
+    set:
+      jobs:
+        job-one:
+          enabled: true
+          command: ["echo"]
+          args: ["one"]
+          externalSecret:
+            enabled: true
+            dataFrom:
+              regexp: "/path/one/.*"
+        job-two:
+          enabled: true
+          command: ["echo"]
+          args: ["two"]
+          externalSecret:
+            enabled: true
+            dataFrom:
+              regexp: "/path/two/.*"
+    asserts:
+      - hasDocuments:
+          count: 2

--- a/charts/k8s-job/tests/job_test.yaml
+++ b/charts/k8s-job/tests/job_test.yaml
@@ -1,0 +1,336 @@
+suite: job tests
+templates:
+  - job.yaml
+tests:
+  - it: should not render when no jobs are defined
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not render when job is disabled
+    set:
+      jobs:
+        my-job:
+          enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render a job when enabled
+    set:
+      jobs:
+        my-job:
+          enabled: true
+          command: ["echo"]
+          args: ["hello"]
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Job
+
+  - it: should render multiple jobs
+    set:
+      jobs:
+        job-one:
+          enabled: true
+          command: ["echo"]
+          args: ["one"]
+        job-two:
+          enabled: true
+          command: ["echo"]
+          args: ["two"]
+    asserts:
+      - hasDocuments:
+          count: 2
+
+  - it: should set correct job name
+    release:
+      name: test-release
+    set:
+      jobs:
+        deploy-lambda:
+          enabled: true
+          command: ["npm"]
+          args: ["run", "deploy"]
+    asserts:
+      - equal:
+          path: metadata.name
+          value: test-release-k8s-job-deploy-lambda
+
+  - it: should use default image when not specified
+    set:
+      jobDefaults:
+        image:
+          repository: node
+          tag: "20-alpine"
+      jobs:
+        my-job:
+          enabled: true
+          command: ["npm"]
+          args: ["test"]
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "node:20-alpine"
+
+  - it: should override image per job
+    set:
+      jobDefaults:
+        image:
+          repository: node
+          tag: "20-alpine"
+      jobs:
+        my-job:
+          enabled: true
+          image:
+            repository: alpine
+            tag: "3.18"
+          command: ["echo"]
+          args: ["hello"]
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "alpine:3.18"
+
+  - it: should set command and args
+    set:
+      jobs:
+        my-job:
+          enabled: true
+          command: ["npm"]
+          args: ["run", "deploy:prod"]
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].command
+          value: ["npm"]
+      - equal:
+          path: spec.template.spec.containers[0].args
+          value: ["run", "deploy:prod"]
+
+  - it: should use default resources
+    set:
+      jobDefaults:
+        resources:
+          limits:
+            cpu: 500m
+            memory: 256Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
+      jobs:
+        my-job:
+          enabled: true
+          command: ["echo"]
+          args: ["hello"]
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.cpu
+          value: 500m
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.memory
+          value: 256Mi
+
+  - it: should override resources per job
+    set:
+      jobDefaults:
+        resources:
+          limits:
+            cpu: 500m
+            memory: 256Mi
+      jobs:
+        my-job:
+          enabled: true
+          command: ["echo"]
+          args: ["hello"]
+          resources:
+            limits:
+              cpu: "2"
+              memory: 1Gi
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.cpu
+          value: "2"
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.memory
+          value: 1Gi
+
+  - it: should set default job spec values
+    set:
+      jobDefaults:
+        ttlSecondsAfterFinished: 600
+        backoffLimit: 1
+        completions: 1
+        parallelism: 1
+      jobs:
+        my-job:
+          enabled: true
+          command: ["echo"]
+          args: ["hello"]
+    asserts:
+      - equal:
+          path: spec.ttlSecondsAfterFinished
+          value: 600
+      - equal:
+          path: spec.backoffLimit
+          value: 1
+      - equal:
+          path: spec.completions
+          value: 1
+      - equal:
+          path: spec.parallelism
+          value: 1
+
+  - it: should override job spec values per job
+    set:
+      jobDefaults:
+        ttlSecondsAfterFinished: 600
+        backoffLimit: 1
+      jobs:
+        my-job:
+          enabled: true
+          command: ["echo"]
+          args: ["hello"]
+          ttlSecondsAfterFinished: 300
+          backoffLimit: 3
+    asserts:
+      - equal:
+          path: spec.ttlSecondsAfterFinished
+          value: 300
+      - equal:
+          path: spec.backoffLimit
+          value: 3
+
+  - it: should set ArgoCD annotations with defaults
+    set:
+      jobDefaults:
+        argocd:
+          hook: PreSync
+          syncWave: "1"
+          hookDeletePolicy: BeforeHookCreation
+      jobs:
+        my-job:
+          enabled: true
+          command: ["echo"]
+          args: ["hello"]
+    asserts:
+      - equal:
+          path: metadata.annotations["argocd.argoproj.io/hook"]
+          value: PreSync
+      - equal:
+          path: metadata.annotations["argocd.argoproj.io/sync-wave"]
+          value: "1"
+      - equal:
+          path: metadata.annotations["argocd.argoproj.io/hook-delete-policy"]
+          value: BeforeHookCreation
+
+  - it: should override ArgoCD hook per job
+    set:
+      jobDefaults:
+        argocd:
+          hook: PreSync
+          syncWave: "1"
+      jobs:
+        my-job:
+          enabled: true
+          command: ["echo"]
+          args: ["hello"]
+          argocd:
+            hook: PostSync
+            syncWave: "5"
+    asserts:
+      - equal:
+          path: metadata.annotations["argocd.argoproj.io/hook"]
+          value: PostSync
+      - equal:
+          path: metadata.annotations["argocd.argoproj.io/sync-wave"]
+          value: "5"
+
+  - it: should set environment variables
+    set:
+      jobs:
+        my-job:
+          enabled: true
+          command: ["echo"]
+          args: ["hello"]
+          env:
+            - name: NODE_ENV
+              value: production
+            - name: AWS_REGION
+              value: us-east-1
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env[0].name
+          value: NODE_ENV
+      - equal:
+          path: spec.template.spec.containers[0].env[0].value
+          value: production
+
+  - it: should set envFrom for secrets
+    set:
+      jobs:
+        my-job:
+          enabled: true
+          command: ["echo"]
+          args: ["hello"]
+          envFrom:
+            - secretRef:
+                name: my-secret
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].envFrom[0].secretRef.name
+          value: my-secret
+
+  - it: should set workingDir
+    set:
+      jobs:
+        my-job:
+          enabled: true
+          command: ["npm"]
+          args: ["run", "build"]
+          workingDir: /app
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].workingDir
+          value: /app
+
+  - it: should set volumes and volumeMounts
+    set:
+      jobs:
+        my-job:
+          enabled: true
+          command: ["echo"]
+          args: ["hello"]
+          volumes:
+            - name: data
+              emptyDir: {}
+          volumeMounts:
+            - name: data
+              mountPath: /data
+    asserts:
+      - equal:
+          path: spec.template.spec.volumes[0].name
+          value: data
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[0].mountPath
+          value: /data
+
+  - it: should have correct labels
+    release:
+      name: test-release
+    set:
+      jobs:
+        my-job:
+          enabled: true
+          command: ["echo"]
+          args: ["hello"]
+    asserts:
+      - equal:
+          path: metadata.labels["app.kubernetes.io/name"]
+          value: k8s-job
+      - equal:
+          path: metadata.labels["app.kubernetes.io/instance"]
+          value: test-release
+      - equal:
+          path: metadata.labels["app.kubernetes.io/component"]
+          value: my-job

--- a/charts/k8s-job/tests/rbac_test.yaml
+++ b/charts/k8s-job/tests/rbac_test.yaml
@@ -1,0 +1,284 @@
+suite: rbac tests
+templates:
+  - role.yaml
+  - rolebinding.yaml
+tests:
+  - it: should not render role when rbac.create is false
+    templates:
+      - role.yaml
+    set:
+      jobs:
+        my-job:
+          enabled: true
+          command: ["echo"]
+          args: ["hello"]
+          rbac:
+            create: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not render rolebinding when rbac.create is false
+    templates:
+      - rolebinding.yaml
+    set:
+      jobs:
+        my-job:
+          enabled: true
+          command: ["echo"]
+          args: ["hello"]
+          rbac:
+            create: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not render role when rules are empty
+    templates:
+      - role.yaml
+    set:
+      jobs:
+        my-job:
+          enabled: true
+          command: ["echo"]
+          args: ["hello"]
+          rbac:
+            create: true
+            rules: []
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render Role when rbac.create is true with rules
+    templates:
+      - role.yaml
+    set:
+      jobs:
+        my-job:
+          enabled: true
+          command: ["echo"]
+          args: ["hello"]
+          rbac:
+            create: true
+            rules:
+              - apiGroups: [""]
+                resources: ["configmaps"]
+                verbs: ["get", "list"]
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Role
+
+  - it: should render RoleBinding when rbac.create is true with rules
+    templates:
+      - rolebinding.yaml
+    set:
+      jobs:
+        my-job:
+          enabled: true
+          command: ["echo"]
+          args: ["hello"]
+          rbac:
+            create: true
+            rules:
+              - apiGroups: [""]
+                resources: ["configmaps"]
+                verbs: ["get", "list"]
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: RoleBinding
+
+  - it: should render ClusterRole when clusterScope is true
+    templates:
+      - role.yaml
+    set:
+      jobs:
+        my-job:
+          enabled: true
+          command: ["echo"]
+          args: ["hello"]
+          rbac:
+            create: true
+            clusterScope: true
+            rules:
+              - apiGroups: [""]
+                resources: ["nodes"]
+                verbs: ["get", "list"]
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ClusterRole
+
+  - it: should render ClusterRoleBinding when clusterScope is true
+    templates:
+      - rolebinding.yaml
+    set:
+      jobs:
+        my-job:
+          enabled: true
+          command: ["echo"]
+          args: ["hello"]
+          rbac:
+            create: true
+            clusterScope: true
+            rules:
+              - apiGroups: [""]
+                resources: ["nodes"]
+                verbs: ["get", "list"]
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ClusterRoleBinding
+
+  - it: should set correct role name
+    templates:
+      - role.yaml
+    release:
+      name: test-release
+    set:
+      jobs:
+        k8s-task:
+          enabled: true
+          command: ["kubectl"]
+          args: ["get", "cm"]
+          rbac:
+            create: true
+            rules:
+              - apiGroups: [""]
+                resources: ["configmaps"]
+                verbs: ["get"]
+    asserts:
+      - equal:
+          path: metadata.name
+          value: test-release-k8s-job-k8s-task
+
+  - it: should set correct rules
+    templates:
+      - role.yaml
+    set:
+      jobs:
+        my-job:
+          enabled: true
+          command: ["echo"]
+          args: ["hello"]
+          rbac:
+            create: true
+            rules:
+              - apiGroups: [""]
+                resources: ["configmaps", "secrets"]
+                verbs: ["get", "list", "watch"]
+    asserts:
+      - equal:
+          path: rules[0].apiGroups
+          value: [""]
+      - equal:
+          path: rules[0].resources
+          value: ["configmaps", "secrets"]
+      - equal:
+          path: rules[0].verbs
+          value: ["get", "list", "watch"]
+
+  - it: should reference correct serviceaccount in rolebinding
+    templates:
+      - rolebinding.yaml
+    release:
+      name: test-release
+    set:
+      jobs:
+        my-job:
+          enabled: true
+          command: ["echo"]
+          args: ["hello"]
+          rbac:
+            create: true
+            rules:
+              - apiGroups: [""]
+                resources: ["configmaps"]
+                verbs: ["get"]
+    asserts:
+      - equal:
+          path: subjects[0].kind
+          value: ServiceAccount
+      - equal:
+          path: subjects[0].name
+          value: test-release-k8s-job-my-job
+
+  - it: should reference correct role in rolebinding
+    templates:
+      - rolebinding.yaml
+    release:
+      name: test-release
+    set:
+      jobs:
+        my-job:
+          enabled: true
+          command: ["echo"]
+          args: ["hello"]
+          rbac:
+            create: true
+            rules:
+              - apiGroups: [""]
+                resources: ["configmaps"]
+                verbs: ["get"]
+    asserts:
+      - equal:
+          path: roleRef.kind
+          value: Role
+      - equal:
+          path: roleRef.name
+          value: test-release-k8s-job-my-job
+
+  - it: should set ArgoCD annotations at sync-wave 0
+    templates:
+      - role.yaml
+    set:
+      jobDefaults:
+        argocd:
+          hook: PreSync
+      jobs:
+        my-job:
+          enabled: true
+          command: ["echo"]
+          args: ["hello"]
+          rbac:
+            create: true
+            rules:
+              - apiGroups: [""]
+                resources: ["configmaps"]
+                verbs: ["get"]
+    asserts:
+      - equal:
+          path: metadata.annotations["argocd.argoproj.io/hook"]
+          value: PreSync
+      - equal:
+          path: metadata.annotations["argocd.argoproj.io/sync-wave"]
+          value: "0"
+
+  - it: should include namespace in ClusterRoleBinding subject
+    templates:
+      - rolebinding.yaml
+    release:
+      name: test-release
+      namespace: my-namespace
+    set:
+      jobs:
+        my-job:
+          enabled: true
+          command: ["echo"]
+          args: ["hello"]
+          rbac:
+            create: true
+            clusterScope: true
+            rules:
+              - apiGroups: [""]
+                resources: ["nodes"]
+                verbs: ["get"]
+    asserts:
+      - equal:
+          path: subjects[0].namespace
+          value: my-namespace

--- a/charts/k8s-job/tests/serviceaccount_test.yaml
+++ b/charts/k8s-job/tests/serviceaccount_test.yaml
@@ -1,0 +1,123 @@
+suite: serviceaccount tests
+templates:
+  - serviceaccount.yaml
+tests:
+  - it: should not render when no jobs are defined
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not render when job is disabled
+    set:
+      jobs:
+        my-job:
+          enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not render when serviceAccount.create is false
+    set:
+      jobs:
+        my-job:
+          enabled: true
+          serviceAccount:
+            create: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render serviceaccount when job is enabled
+    set:
+      jobs:
+        my-job:
+          enabled: true
+          command: ["echo"]
+          args: ["hello"]
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ServiceAccount
+
+  - it: should set correct serviceaccount name
+    release:
+      name: test-release
+    set:
+      jobs:
+        deploy-lambda:
+          enabled: true
+          command: ["npm"]
+          args: ["deploy"]
+    asserts:
+      - equal:
+          path: metadata.name
+          value: test-release-k8s-job-deploy-lambda
+
+  - it: should set ArgoCD annotations at sync-wave 0
+    set:
+      jobDefaults:
+        argocd:
+          hook: PreSync
+      jobs:
+        my-job:
+          enabled: true
+          command: ["echo"]
+          args: ["hello"]
+    asserts:
+      - equal:
+          path: metadata.annotations["argocd.argoproj.io/hook"]
+          value: PreSync
+      - equal:
+          path: metadata.annotations["argocd.argoproj.io/sync-wave"]
+          value: "0"
+
+  - it: should set custom serviceaccount annotations
+    set:
+      jobs:
+        my-job:
+          enabled: true
+          command: ["echo"]
+          args: ["hello"]
+          serviceAccount:
+            annotations:
+              eks.amazonaws.com/role-arn: arn:aws:iam::123456789:role/my-role
+    asserts:
+      - equal:
+          path: metadata.annotations["eks.amazonaws.com/role-arn"]
+          value: arn:aws:iam::123456789:role/my-role
+
+  - it: should render multiple serviceaccounts for multiple jobs
+    set:
+      jobs:
+        job-one:
+          enabled: true
+          command: ["echo"]
+          args: ["one"]
+        job-two:
+          enabled: true
+          command: ["echo"]
+          args: ["two"]
+    asserts:
+      - hasDocuments:
+          count: 2
+
+  - it: should have correct labels
+    release:
+      name: test-release
+    set:
+      jobs:
+        my-job:
+          enabled: true
+          command: ["echo"]
+          args: ["hello"]
+    asserts:
+      - equal:
+          path: metadata.labels["app.kubernetes.io/name"]
+          value: k8s-job
+      - equal:
+          path: metadata.labels["app.kubernetes.io/instance"]
+          value: test-release
+      - equal:
+          path: metadata.labels["app.kubernetes.io/component"]
+          value: my-job

--- a/charts/k8s-job/values.yaml
+++ b/charts/k8s-job/values.yaml
@@ -1,0 +1,111 @@
+---
+nameOverride: ""
+fullnameOverride: ""
+
+imagePullSecrets: []
+
+# Default values applied to all jobs (can be overridden per job)
+jobDefaults:
+  image:
+    repository: node
+    tag: "20-alpine"
+    pullPolicy: IfNotPresent
+
+  # Job spec defaults
+  ttlSecondsAfterFinished: 600
+  backoffLimit: 1
+  completions: 1
+  parallelism: 1
+
+  # ArgoCD hook configuration
+  argocd:
+    hook: PreSync
+    syncWave: "1"
+    hookDeletePolicy: BeforeHookCreation
+
+  # Container defaults
+  command: []
+  args: []
+  workingDir: ""
+
+  # Environment configuration
+  env: []
+  envFrom: []
+
+  # Resource defaults
+  resources:
+    limits:
+      cpu: 500m
+      memory: 256Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
+
+  # Security contexts
+  podSecurityContext: {}
+  securityContext: {}
+
+  # Scheduling
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+  # Volumes
+  volumes: []
+  volumeMounts: []
+
+  # RBAC defaults
+  serviceAccount:
+    create: true
+    annotations: {}
+  rbac:
+    create: false
+    clusterScope: false
+    rules: []
+
+  # External Secrets defaults
+  externalSecret:
+    enabled: false
+    # name: ""  # defaults to job fullname
+    refreshInterval: "0"
+    refreshPolicy: OnChange
+    secretStoreRef:
+      name: aws-parameter-store-cluster
+      kind: ClusterSecretStore
+    creationPolicy: Owner
+    deletionPolicy: Retain
+    dataFrom:
+      path: ""
+      regexp: ""
+      rewrite: {}
+        # source: ""
+        # target: ""
+
+# List of jobs to create
+# Each job inherits from jobDefaults and can override any value
+jobs: {}
+  # Example job configuration:
+  # deploy-lambda:
+  #   enabled: true
+  #   image:
+  #     repository: node
+  #     tag: "20-alpine"
+  #   command: ["npm"]
+  #   args: ["run", "deploy:prod"]
+  #   workingDir: /app
+  #   env:
+  #     - name: AWS_REGION
+  #       value: us-east-1
+  #   envFrom:
+  #     - secretRef:
+  #         name: aws-credentials
+  #   resources:
+  #     limits:
+  #       cpu: "1"
+  #       memory: 512Mi
+  #   serviceAccount:
+  #     create: true
+  #     annotations:
+  #       eks.amazonaws.com/role-arn: arn:aws:iam::123456789:role/lambda-deploy
+  #   rbac:
+  #     create: false


### PR DESCRIPTION
## feat: add k8s-job helm chart

This pull request introduces a new, highly flexible Helm chart called `k8s-job` for deploying generic Kubernetes Jobs with per-job configuration, RBAC, service account management, ArgoCD integration, and support for External Secrets. The chart is designed to support multiple jobs per release, with global defaults and per-job overrides, and provides templates for all associated Kubernetes resources.

The most important changes include:

**1. New Helm Chart Definition and Documentation**
- Added `charts/k8s-job/Chart.yaml` defining the new `k8s-job` chart, including metadata and versioning.
- Added a comprehensive `charts/k8s-job/README.md` describing chart features, configuration options, usage examples, and installation instructions.

**2. Template Logic and Helpers**
- Implemented `_helpers.tpl` with functions for generating resource names, labels, and merging global/job-specific configuration, enabling powerful per-job customization and DRY templates.

**3. Kubernetes Resource Templates**
- Added templates for all required Kubernetes resources, each supporting per-job configuration:
  - [`job.yaml`](diffhunk://#diff-a6bf11a606989640e64a3acf559bf560e57626525f2e6769e6402533d202a3b9R1-R93): Renders one Job per enabled job definition, supporting overrides for image, command, resources, etc.
  - [`serviceaccount.yaml`](diffhunk://#diff-9c8b4aa176358189e6f972b81a7bc8b172559cd1e44c7825b33358d0c05ac3e5R1-R23): Creates a dedicated ServiceAccount for each job, with support for IRSA annotations and ArgoCD sync waves.
  - `role.yaml` and `rolebinding.yaml`: Conditionally create Role/ClusterRole and RoleBinding/ClusterRoleBinding per job, based on RBAC config, supporting both namespaced and cluster-scoped permissions. [[1]](diffhunk://#diff-2cdb669b6230edf0f53cb9cdd4a205ed6b64c95965d94a861f3b76a68a500b64R1-R37) [[2]](diffhunk://#diff-57f0c4bb8fec891d8fbad58d9d68cb8ad538446dbd09c37ad589a1f14cceeb31R1-R48)
  - [`external-secrets.yaml`](diffhunk://#diff-d4b190e4a39d999410190347f3845015d7dcfe4b13e5c017ee90a262e79dd18bR1-R43): Integrates with External Secrets Operator, allowing jobs to consume secrets from external stores via flexible path/regex configuration.

This chart provides a robust foundation for managing complex job-based workflows in Kubernetes with GitOps and cloud-native best practices.