### PR TITLE
feat(k8s-job): external secret to accept multiple dataFrom

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -30,6 +30,7 @@ jobs:
             deployment
             external-secrets-refresher
             external-services
+            k8s-job
             releem-agent
           # Configure that a scope must always be provided.
           requireScope: false

--- a/charts/k8s-job/Chart.yaml
+++ b/charts/k8s-job/Chart.yaml
@@ -3,8 +3,8 @@ apiVersion: v2
 name: k8s-job
 description: A Helm chart to deploy generic Kubernetes jobs with configurable RBAC
 type: application
-version: 0.1.0
-appVersion: "0.1.0"
+version: 0.2.0
+appVersion: "0.2.0"
 
 home: https://github.com/pltf-dev/helm-charts
 # icon: https://.svg

--- a/charts/k8s-job/README.md
+++ b/charts/k8s-job/README.md
@@ -94,11 +94,39 @@ jobs:
       enabled: true
       name: lambda-secrets
       dataFrom:
-        path: /cf2/production/lambda/
+        path: /lambda/
         regexp: ".*"
         rewrite:
-          source: "/cf2/production/lambda/(.*)"
+          source: "/lambda/(.*)"
           target: "$1"
+```
+
+### Job with Multiple External Secret Paths
+
+```yaml
+jobs:
+  deploy-lambda:
+    enabled: true
+    command: ["npm"]
+    args: ["run", "deploy:prod"]
+    envFrom:
+      - secretRef:
+          name: lambda-secrets
+    externalSecret:
+      enabled: true
+      name: lambda-secrets
+      # dataFrom supports an array for multiple paths
+      dataFrom:
+        - path: /lambda/
+          regexp: ".*"
+          rewrite:
+            source: "/lambda/(.*)"
+            target: "$1"
+        - path: /shared/
+          regexp: "S3_.*"
+          rewrite:
+            source: "/shared/(.*)"
+            target: "$1"
 ```
 
 ## Configuration

--- a/charts/k8s-job/templates/_helpers.tpl
+++ b/charts/k8s-job/templates/_helpers.tpl
@@ -162,16 +162,19 @@ Usage: {{ include "k8s-job.mergeJobConfig" (dict "root" . "jobName" $jobName "jo
 {{- $defaultStoreRef := $defaultES.secretStoreRef | default dict }}
 {{- $jobStoreRef := $jobES.secretStoreRef | default dict }}
 {{- $_ := set $mergedES "secretStoreRef" (merge $jobStoreRef $defaultStoreRef) }}
-{{/* Merge dataFrom */}}
-{{- $defaultDataFrom := $defaultES.dataFrom | default dict }}
-{{- $jobDataFrom := $jobES.dataFrom | default dict }}
-{{- $mergedDataFrom := dict }}
-{{- $_ := set $mergedDataFrom "path" ($jobDataFrom.path | default $defaultDataFrom.path) }}
-{{- $_ := set $mergedDataFrom "regexp" ($jobDataFrom.regexp | default $defaultDataFrom.regexp) }}
-{{- $defaultRewrite := $defaultDataFrom.rewrite | default dict }}
-{{- $jobRewrite := $jobDataFrom.rewrite | default dict }}
-{{- $_ := set $mergedDataFrom "rewrite" (merge $jobRewrite $defaultRewrite) }}
-{{- $_ := set $mergedES "dataFrom" $mergedDataFrom }}
+{{/* Merge dataFrom - supports both single object and array formats */}}
+{{- $jobDataFrom := $jobES.dataFrom }}
+{{- $defaultDataFrom := $defaultES.dataFrom }}
+{{- if $jobDataFrom }}
+  {{- /* Job has dataFrom defined, use it directly (array or object) */}}
+  {{- $_ := set $mergedES "dataFrom" $jobDataFrom }}
+{{- else if $defaultDataFrom }}
+  {{- /* Fall back to defaults */}}
+  {{- $_ := set $mergedES "dataFrom" $defaultDataFrom }}
+{{- else }}
+  {{- /* No dataFrom defined anywhere, use empty dict */}}
+  {{- $_ := set $mergedES "dataFrom" dict }}
+{{- end }}
 {{- $_ := set $merged "externalSecret" $mergedES }}
 
 {{- $merged | toJson }}

--- a/charts/k8s-job/templates/external-secrets.yaml
+++ b/charts/k8s-job/templates/external-secrets.yaml
@@ -26,6 +26,24 @@ spec:
     creationPolicy: {{ $es.creationPolicy | default "Owner" }}
     deletionPolicy: {{ $es.deletionPolicy | default "Retain" }}
   dataFrom:
+    {{- if kindIs "slice" $es.dataFrom }}
+    {{- /* Multiple dataFrom entries (array format) */}}
+    {{- range $dataFromEntry := $es.dataFrom }}
+    - find:
+        {{- if $dataFromEntry.path }}
+        path: {{ $dataFromEntry.path }}
+        {{- end }}
+        name:
+          regexp: {{ $dataFromEntry.regexp | quote }}
+      {{- if $dataFromEntry.rewrite }}
+      rewrite:
+        - regexp:
+            source: {{ $dataFromEntry.rewrite.source | quote }}
+            target: {{ $dataFromEntry.rewrite.target | quote }}
+      {{- end }}
+    {{- end }}
+    {{- else }}
+    {{- /* Single dataFrom entry (legacy object format for backward compatibility) */}}
     - find:
         {{- if $es.dataFrom.path }}
         path: {{ $es.dataFrom.path }}
@@ -38,6 +56,7 @@ spec:
             source: {{ $es.dataFrom.rewrite.source | quote }}
             target: {{ $es.dataFrom.rewrite.target | quote }}
       {{- end }}
+    {{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/k8s-job/tests/external-secrets_test.yaml
+++ b/charts/k8s-job/tests/external-secrets_test.yaml
@@ -54,7 +54,7 @@ tests:
           externalSecret:
             enabled: true
             dataFrom:
-              regexp: "/cf2/production/.*"
+              regexp: "/app/production/.*"
     asserts:
       - hasDocuments:
           count: 1
@@ -209,11 +209,11 @@ tests:
           externalSecret:
             enabled: true
             dataFrom:
-              regexp: "/cf2/production/lambda/.*"
+              regexp: "/app/production/lambda/.*"
     asserts:
       - equal:
           path: spec.dataFrom[0].find.name.regexp
-          value: "/cf2/production/lambda/.*"
+          value: "/app/production/lambda/.*"
       - isNull:
           path: spec.dataFrom[0].find.path
 
@@ -227,12 +227,12 @@ tests:
           externalSecret:
             enabled: true
             dataFrom:
-              path: /cf2/production/lambda/
+              path: /app/production/lambda/
               regexp: ".*"
     asserts:
       - equal:
           path: spec.dataFrom[0].find.path
-          value: /cf2/production/lambda/
+          value: /app/production/lambda/
       - equal:
           path: spec.dataFrom[0].find.name.regexp
           value: ".*"
@@ -247,15 +247,15 @@ tests:
           externalSecret:
             enabled: true
             dataFrom:
-              path: /cf2/production/lambda/
+              path: /app/production/lambda/
               regexp: ".*"
               rewrite:
-                source: "/cf2/production/lambda/(.*)"
+                source: "/app/production/lambda/(.*)"
                 target: "$1"
     asserts:
       - equal:
           path: spec.dataFrom[0].rewrite[0].regexp.source
-          value: "/cf2/production/lambda/(.*)"
+          value: "/app/production/lambda/(.*)"
       - equal:
           path: spec.dataFrom[0].rewrite[0].regexp.target
           value: "$1"
@@ -314,6 +314,138 @@ tests:
       - equal:
           path: metadata.labels["app.kubernetes.io/component"]
           value: my-job
+
+  - it: should set dataFrom array with multiple entries
+    set:
+      jobs:
+        my-job:
+          enabled: true
+          command: ["echo"]
+          args: ["hello"]
+          externalSecret:
+            enabled: true
+            dataFrom:
+              - path: /lambda/my-lambda/
+                regexp: ".*"
+                rewrite:
+                  source: "/lambda/my-lambda/(.*)"
+                  target: "$1"
+              - path: /shared/
+                regexp: "S3_CLOUD_.*"
+                rewrite:
+                  source: "/shared/(.*)"
+                  target: "$1"
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.dataFrom[0].find.path
+          value: /lambda/my-lambda/
+      - equal:
+          path: spec.dataFrom[0].find.name.regexp
+          value: ".*"
+      - equal:
+          path: spec.dataFrom[0].rewrite[0].regexp.source
+          value: "/lambda/my-lambda/(.*)"
+      - equal:
+          path: spec.dataFrom[0].rewrite[0].regexp.target
+          value: "$1"
+      - equal:
+          path: spec.dataFrom[1].find.path
+          value: /shared/
+      - equal:
+          path: spec.dataFrom[1].find.name.regexp
+          value: "S3_CLOUD_.*"
+      - equal:
+          path: spec.dataFrom[1].rewrite[0].regexp.source
+          value: "/shared/(.*)"
+      - equal:
+          path: spec.dataFrom[1].rewrite[0].regexp.target
+          value: "$1"
+
+  - it: should set dataFrom array with regexp only (no path)
+    set:
+      jobs:
+        my-job:
+          enabled: true
+          command: ["echo"]
+          args: ["hello"]
+          externalSecret:
+            enabled: true
+            dataFrom:
+              - regexp: "/app/production/.*"
+              - regexp: "/app/staging/.*"
+    asserts:
+      - equal:
+          path: spec.dataFrom[0].find.name.regexp
+          value: "/app/production/.*"
+      - isNull:
+          path: spec.dataFrom[0].find.path
+      - isNull:
+          path: spec.dataFrom[0].rewrite
+      - equal:
+          path: spec.dataFrom[1].find.name.regexp
+          value: "/app/staging/.*"
+      - isNull:
+          path: spec.dataFrom[1].find.path
+      - isNull:
+          path: spec.dataFrom[1].rewrite
+
+  - it: should set dataFrom array with mixed entries (some with rewrite, some without)
+    set:
+      jobs:
+        my-job:
+          enabled: true
+          command: ["echo"]
+          args: ["hello"]
+          externalSecret:
+            enabled: true
+            dataFrom:
+              - path: /lambda/my-lambda/
+                regexp: ".*"
+                rewrite:
+                  source: "/lambda/my-lambda/(.*)"
+                  target: "$1"
+              - regexp: "/shared/S3_CLOUD_.*"
+    asserts:
+      - equal:
+          path: spec.dataFrom[0].find.path
+          value: /lambda/my-lambda/
+      - equal:
+          path: spec.dataFrom[0].find.name.regexp
+          value: ".*"
+      - equal:
+          path: spec.dataFrom[0].rewrite[0].regexp.source
+          value: "/lambda/my-lambda/(.*)"
+      - isNull:
+          path: spec.dataFrom[1].find.path
+      - equal:
+          path: spec.dataFrom[1].find.name.regexp
+          value: "/shared/S3_CLOUD_.*"
+      - isNull:
+          path: spec.dataFrom[1].rewrite
+
+  - it: should set dataFrom array with single entry
+    set:
+      jobs:
+        my-job:
+          enabled: true
+          command: ["echo"]
+          args: ["hello"]
+          externalSecret:
+            enabled: true
+            dataFrom:
+              - path: /app/production/lambda/
+                regexp: ".*"
+    asserts:
+      - equal:
+          path: spec.dataFrom[0].find.path
+          value: /app/production/lambda/
+      - equal:
+          path: spec.dataFrom[0].find.name.regexp
+          value: ".*"
+      - isNull:
+          path: spec.dataFrom[0].rewrite
 
   - it: should render multiple ExternalSecrets for multiple jobs
     set:

--- a/charts/k8s-job/values.yaml
+++ b/charts/k8s-job/values.yaml
@@ -74,12 +74,26 @@ jobDefaults:
       kind: ClusterSecretStore
     creationPolicy: Owner
     deletionPolicy: Retain
+    # dataFrom can be a single object (legacy) or an array of objects (for multiple paths)
+    # Single path example:
     dataFrom:
       path: ""
       regexp: ""
       rewrite: {}
         # source: ""
         # target: ""
+    # Multiple paths example:
+    # dataFrom:
+    #   - path: /lambda/my-lambda/
+    #     regexp: ".*"
+    #     rewrite:
+    #       source: "/lambda/my-lambda/(.*)"
+    #       target: "$1"
+    #   - path: /shared/
+    #     regexp: "S3_CLOUD_.*"
+    #     rewrite:
+    #       source: "/shared/(.*)"
+    #       target: "$1"
 
 # List of jobs to create
 # Each job inherits from jobDefaults and can override any value
@@ -91,7 +105,7 @@ jobs: {}
   #     repository: node
   #     tag: "20-alpine"
   #   command: ["npm"]
-  #   args: ["run", "deploy:prod"]
+  #   args: ["run", "deploy"]
   #   workingDir: /app
   #   env:
   #     - name: AWS_REGION


### PR DESCRIPTION
## feat(k8s-job): external secret to accept multiple dataFrom

This pull request introduces enhancements to the `k8s-job` Helm chart, mainly focusing on supporting multiple external secret paths for Kubernetes jobs and improving configuration flexibility. The changes also update documentation and examples to reflect these improvements.

**External Secret Paths Support:**

* Added support for specifying multiple `dataFrom` entries (array format) in external secrets, allowing jobs to source secrets from multiple paths. The template logic in `external-secrets.yaml` now handles both legacy single-object and new array formats for backward compatibility. [[1]](diffhunk://#diff-d4b190e4a39d999410190347f3845015d7dcfe4b13e5c017ee90a262e79dd18bR29-R46) [[2]](diffhunk://#diff-d4b190e4a39d999410190347f3845015d7dcfe4b13e5c017ee90a262e79dd18bR62) [[3]](diffhunk://#diff-e1d3fb59a4f2566b21c0a80e0a12a98dd9a559ace782b41c157f8a8530847451L165-R177)
* Updated `values.yaml` to document and provide examples for both single and multiple `dataFrom` configurations under `jobDefaults`, clarifying usage for users.

**Documentation and Examples:**

* Expanded the `README.md` with a new example for jobs using multiple external secret paths, and clarified the rewrite logic for secret paths.
* Adjusted example job arguments in `values.yaml` to better match typical usage.

**Chart Versioning and Workflow Integration:**

* Bumped the chart version to `0.2.0` in `Chart.yaml` to reflect these new features.
* Added `k8s-job` to the list of jobs in the GitHub Actions workflow for PR title checks, ensuring CI coverage. (.github/workflows/pr-title.yml)