### PR TITLE
feat(k8s-job): add global image support

### DIFF
--- a/charts/k8s-job/Chart.yaml
+++ b/charts/k8s-job/Chart.yaml
@@ -3,8 +3,8 @@ apiVersion: v2
 name: k8s-job
 description: A Helm chart to deploy generic Kubernetes jobs with configurable RBAC
 type: application
-version: 0.2.0
-appVersion: "0.2.0"
+version: 0.2.1
+appVersion: "0.2.1"
 
 home: https://github.com/pltf-dev/helm-charts
 # icon: https://.svg

--- a/charts/k8s-job/README.md
+++ b/charts/k8s-job/README.md
@@ -131,6 +131,30 @@ jobs:
 
 ## Configuration
 
+### Global Image (for Subcharts)
+
+When using k8s-job as a subchart dependency, the parent chart can set a global image that all jobs will inherit. This is useful when you want all subcharts to share the same image.
+
+```yaml
+# In parent chart values.yaml
+global:
+  image:
+    repository: alpine/k8s
+    tag: "1.34.1"
+    pullPolicy: IfNotPresent
+
+k8s-job:
+  enabled: true
+  jobs:
+    deploy-lambda:
+      enabled: true
+      command: ["npm"]
+      args: ["run", "deploy"]
+      # Uses global.image automatically
+```
+
+**Image Priority**: job-specific > global > jobDefaults
+
 ### Global Defaults (`jobDefaults`)
 
 | Parameter | Description | Default |

--- a/charts/k8s-job/templates/_helpers.tpl
+++ b/charts/k8s-job/templates/_helpers.tpl
@@ -74,12 +74,16 @@ Usage: {{ include "k8s-job.mergeJobConfig" (dict "root" . "jobName" $jobName "jo
 {{- define "k8s-job.mergeJobConfig" -}}
 {{- $defaults := .root.Values.jobDefaults }}
 {{- $job := .jobConfig }}
+{{- $global := .root.Values.global | default dict }}
 {{- $merged := dict }}
 
-{{/* Merge image */}}
+{{/* Merge image with priority: job > global > jobDefaults */}}
+{{/* Global image takes precedence over jobDefaults when explicitly set */}}
+{{- $globalImage := $global.image | default dict }}
 {{- $defaultImage := $defaults.image | default dict }}
 {{- $jobImage := $job.image | default dict }}
-{{- $_ := set $merged "image" (merge $jobImage $defaultImage) }}
+{{- $baseImage := merge $globalImage $defaultImage }}
+{{- $_ := set $merged "image" (merge $jobImage $baseImage) }}
 
 {{/* Merge simple values with defaults */}}
 {{- $_ := set $merged "ttlSecondsAfterFinished" ($job.ttlSecondsAfterFinished | default $defaults.ttlSecondsAfterFinished) }}

--- a/charts/k8s-job/values.yaml
+++ b/charts/k8s-job/values.yaml
@@ -4,7 +4,17 @@ fullnameOverride: ""
 
 imagePullSecrets: []
 
+# Global configuration (typically set by parent chart)
+# When used as a subchart, the parent can set global.image to share
+# image configuration across multiple subcharts
+global:
+  image:
+    # repository: alpine/k8s
+    # tag: "1.34.1"
+    # pullPolicy: IfNotPresent
+
 # Default values applied to all jobs (can be overridden per job)
+# Priority: job-specific > global > jobDefaults
 jobDefaults:
   image:
     repository: node


### PR DESCRIPTION
## feat(k8s-job): add global image support

This pull request updates the `k8s-job` Helm chart to introduce support for a global image configuration, allowing parent charts to specify a single image for all jobs in subcharts. This makes it easier to manage and standardize images across multiple jobs. The image selection now follows a clear priority: job-specific > global > jobDefaults. The documentation, values file, and helper templates have been updated accordingly.

**Global Image Support and Configuration:**

* Added a `global.image` section in `values.yaml` to allow parent charts to specify a shared image configuration for all jobs in subcharts.
* Updated the README with documentation and usage examples for the new global image feature, including a note on image priority.

**Image Merge Logic:**

* Modified the `_helpers.tpl` merge logic so that image configuration priority is: job-specific > global > jobDefaults. The template now merges global image values with jobDefaults, and then merges job-specific settings on top.

**Versioning:**

* Bumped chart version and appVersion from `0.2.0` to `0.2.1` to reflect the new feature.