### PR TITLE
fix(k8s-job): fix global values, bump version

### DIFF
--- a/charts/k8s-job/Chart.yaml
+++ b/charts/k8s-job/Chart.yaml
@@ -3,8 +3,8 @@ apiVersion: v2
 name: k8s-job
 description: A Helm chart to deploy generic Kubernetes jobs with configurable RBAC
 type: application
-version: 0.2.1
-appVersion: "0.2.1"
+version: 0.2.2
+appVersion: "0.2.2"
 
 home: https://github.com/pltf-dev/helm-charts
 # icon: https://.svg

--- a/charts/k8s-job/tests/job_test.yaml
+++ b/charts/k8s-job/tests/job_test.yaml
@@ -315,6 +315,140 @@ tests:
           path: spec.template.spec.containers[0].volumeMounts[0].mountPath
           value: /data
 
+  - it: should use global image when set
+    set:
+      global:
+        image:
+          repository: 123456789.dkr.ecr.us-east-1.amazonaws.com/my-app
+          tag: "abc123"
+      jobs:
+        my-job:
+          enabled: true
+          command: ["npm"]
+          args: ["run", "deploy"]
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "123456789.dkr.ecr.us-east-1.amazonaws.com/my-app:abc123"
+
+  - it: should override global image with job-specific image
+    set:
+      global:
+        image:
+          repository: 123456789.dkr.ecr.us-east-1.amazonaws.com/my-app
+          tag: "abc123"
+      jobs:
+        my-job:
+          enabled: true
+          image:
+            repository: custom-repo/custom-image
+            tag: "v2.0.0"
+          command: ["echo"]
+          args: ["hello"]
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "custom-repo/custom-image:v2.0.0"
+
+  - it: should use global image over jobDefaults
+    set:
+      global:
+        image:
+          repository: global-repo/app
+          tag: "global-tag"
+      jobDefaults:
+        image:
+          repository: default-repo/app
+          tag: "default-tag"
+      jobs:
+        my-job:
+          enabled: true
+          command: ["echo"]
+          args: ["hello"]
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "global-repo/app:global-tag"
+
+  - it: should allow job to override only the tag while using global repository
+    set:
+      global:
+        image:
+          repository: global-repo/app
+          tag: "global-tag"
+      jobs:
+        my-job:
+          enabled: true
+          image:
+            tag: "job-specific-tag"
+          command: ["echo"]
+          args: ["hello"]
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "global-repo/app:job-specific-tag"
+
+  - it: should fall back to jobDefaults when global image is empty
+    set:
+      global: {}
+      jobDefaults:
+        image:
+          repository: node
+          tag: "20-alpine"
+      jobs:
+        my-job:
+          enabled: true
+          command: ["echo"]
+          args: ["hello"]
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "node:20-alpine"
+
+  - it: should use global repository with jobDefaults tag as fallback
+    set:
+      global:
+        image:
+          repository: global-repo/app
+      jobDefaults:
+        image:
+          repository: default-repo/app
+          tag: "default-tag"
+      jobs:
+        my-job:
+          enabled: true
+          command: ["echo"]
+          args: ["hello"]
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "global-repo/app:default-tag"
+
+  - it: should apply global image to all jobs
+    set:
+      global:
+        image:
+          repository: shared-repo/app
+          tag: "shared-tag"
+      jobs:
+        job-one:
+          enabled: true
+          command: ["echo"]
+          args: ["one"]
+        job-two:
+          enabled: true
+          command: ["echo"]
+          args: ["two"]
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "shared-repo/app:shared-tag"
+        documentIndex: 0
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "shared-repo/app:shared-tag"
+        documentIndex: 1
+
   - it: should have correct labels
     release:
       name: test-release

--- a/charts/k8s-job/values.yaml
+++ b/charts/k8s-job/values.yaml
@@ -7,11 +7,13 @@ imagePullSecrets: []
 # Global configuration (typically set by parent chart)
 # When used as a subchart, the parent can set global.image to share
 # image configuration across multiple subcharts
-global:
-  image:
-    # repository: alpine/k8s
-    # tag: "1.34.1"
-    # pullPolicy: IfNotPresent
+# Example:
+#   global:
+#     image:
+#       repository: my-ecr.com/app
+#       tag: v1.0.0
+#       pullPolicy: IfNotPresent
+global: {}
 
 # Default values applied to all jobs (can be overridden per job)
 # Priority: job-specific > global > jobDefaults


### PR DESCRIPTION
## fix(k8s-job): fix global values, bump version

This pull request updates the `k8s-job` Helm chart to improve and clarify the logic for image selection across global, jobDefaults, and job-specific settings, and adds comprehensive tests to ensure the correct behavior. It also bumps the chart version to 0.2.2.

**Testing enhancements for image selection:**

* Added multiple test cases in `job_test.yaml` to verify the precedence and fallback logic for selecting container images, including scenarios for global image usage, job-specific overrides, partial overrides (e.g., only tag), fallback to jobDefaults, and application of global images to multiple jobs.

**Configuration improvements:**

* Updated the `values.yaml` example and default to clarify how to set global image configuration, making `global` an empty object by default and providing a commented example for users.

**Chart versioning:**

* Bumped the `version` and `appVersion` in `Chart.yaml` from 0.2.1 to 0.2.2 to reflect these changes.