### PR TITLE
feat(k8s-job): add serviceAccountName

### DIFF
--- a/charts/k8s-job/Chart.yaml
+++ b/charts/k8s-job/Chart.yaml
@@ -3,8 +3,8 @@ apiVersion: v2
 name: k8s-job
 description: A Helm chart to deploy generic Kubernetes jobs with configurable RBAC
 type: application
-version: 0.2.2
-appVersion: "0.2.2"
+version: 0.3.0
+appVersion: "0.3.0"
 
 home: https://github.com/pltf-dev/helm-charts
 # icon: https://.svg

--- a/charts/k8s-job/templates/_helpers.tpl
+++ b/charts/k8s-job/templates/_helpers.tpl
@@ -121,6 +121,9 @@ Usage: {{ include "k8s-job.mergeJobConfig" (dict "root" . "jobName" $jobName "jo
 {{- $_ := set $merged "volumes" ($job.volumes | default $defaults.volumes) }}
 {{- $_ := set $merged "volumeMounts" ($job.volumeMounts | default $defaults.volumeMounts) }}
 
+{{/* Merge serviceAccountName */}}
+{{- $_ := set $merged "serviceAccountName" ($job.serviceAccountName | default $defaults.serviceAccountName) }}
+
 {{/* Merge serviceAccount - check job-level create first, then default */}}
 {{- $defaultSA := $defaults.serviceAccount | default dict }}
 {{- $jobSA := $job.serviceAccount | default dict }}

--- a/charts/k8s-job/templates/job.yaml
+++ b/charts/k8s-job/templates/job.yaml
@@ -29,7 +29,11 @@ spec:
         app.kubernetes.io/component: {{ $jobName }}
     spec:
       restartPolicy: Never
+      {{- if $merged.serviceAccount.create }}
       serviceAccountName: {{ $fullname }}
+      {{- else if $merged.serviceAccountName }}
+      serviceAccountName: {{ $merged.serviceAccountName }}
+      {{- end }}
       {{- with $merged.podSecurityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}

--- a/charts/k8s-job/tests/job_test.yaml
+++ b/charts/k8s-job/tests/job_test.yaml
@@ -449,6 +449,94 @@ tests:
           value: "shared-repo/app:shared-tag"
         documentIndex: 1
 
+  - it: should not set serviceAccountName when neither serviceAccountName nor serviceAccount.create is set
+    set:
+      jobs:
+        my-job:
+          enabled: true
+          command: ["echo"]
+          args: ["hello"]
+    asserts:
+      - notExists:
+          path: spec.template.spec.serviceAccountName
+
+  - it: should use existing serviceAccountName when specified
+    release:
+      name: test-release
+    set:
+      jobs:
+        my-job:
+          enabled: true
+          command: ["echo"]
+          args: ["hello"]
+          serviceAccountName: my-existing-sa
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: my-existing-sa
+
+  - it: should use generated serviceAccountName when serviceAccount.create is true
+    release:
+      name: test-release
+    set:
+      jobs:
+        my-job:
+          enabled: true
+          command: ["echo"]
+          args: ["hello"]
+          serviceAccount:
+            create: true
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: test-release-k8s-job-my-job
+
+  - it: should prefer serviceAccount.create over serviceAccountName
+    release:
+      name: test-release
+    set:
+      jobs:
+        my-job:
+          enabled: true
+          command: ["echo"]
+          args: ["hello"]
+          serviceAccountName: my-existing-sa
+          serviceAccount:
+            create: true
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: test-release-k8s-job-my-job
+
+  - it: should use jobDefaults serviceAccountName
+    set:
+      jobDefaults:
+        serviceAccountName: default-sa
+      jobs:
+        my-job:
+          enabled: true
+          command: ["echo"]
+          args: ["hello"]
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: default-sa
+
+  - it: should override jobDefaults serviceAccountName per job
+    set:
+      jobDefaults:
+        serviceAccountName: default-sa
+      jobs:
+        my-job:
+          enabled: true
+          command: ["echo"]
+          args: ["hello"]
+          serviceAccountName: job-specific-sa
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: job-specific-sa
+
   - it: should have correct labels
     release:
       name: test-release

--- a/charts/k8s-job/tests/serviceaccount_test.yaml
+++ b/charts/k8s-job/tests/serviceaccount_test.yaml
@@ -27,13 +27,26 @@ tests:
       - hasDocuments:
           count: 0
 
-  - it: should render serviceaccount when job is enabled
+  - it: should not render when serviceAccount.create is not set (defaults to false)
     set:
       jobs:
         my-job:
           enabled: true
           command: ["echo"]
           args: ["hello"]
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render serviceaccount when serviceAccount.create is true
+    set:
+      jobs:
+        my-job:
+          enabled: true
+          command: ["echo"]
+          args: ["hello"]
+          serviceAccount:
+            create: true
     asserts:
       - hasDocuments:
           count: 1
@@ -49,6 +62,8 @@ tests:
           enabled: true
           command: ["npm"]
           args: ["deploy"]
+          serviceAccount:
+            create: true
     asserts:
       - equal:
           path: metadata.name
@@ -64,6 +79,8 @@ tests:
           enabled: true
           command: ["echo"]
           args: ["hello"]
+          serviceAccount:
+            create: true
     asserts:
       - equal:
           path: metadata.annotations["argocd.argoproj.io/hook"]
@@ -80,6 +97,7 @@ tests:
           command: ["echo"]
           args: ["hello"]
           serviceAccount:
+            create: true
             annotations:
               eks.amazonaws.com/role-arn: arn:aws:iam::123456789:role/my-role
     asserts:
@@ -94,10 +112,14 @@ tests:
           enabled: true
           command: ["echo"]
           args: ["one"]
+          serviceAccount:
+            create: true
         job-two:
           enabled: true
           command: ["echo"]
           args: ["two"]
+          serviceAccount:
+            create: true
     asserts:
       - hasDocuments:
           count: 2
@@ -111,6 +133,8 @@ tests:
           enabled: true
           command: ["echo"]
           args: ["hello"]
+          serviceAccount:
+            create: true
     asserts:
       - equal:
           path: metadata.labels["app.kubernetes.io/name"]

--- a/charts/k8s-job/values.yaml
+++ b/charts/k8s-job/values.yaml
@@ -20,7 +20,7 @@ global: {}
 jobDefaults:
   image:
     repository: node
-    tag: "20-alpine"
+    tag: "24-alpine"
     pullPolicy: IfNotPresent
 
   # Job spec defaults
@@ -31,7 +31,7 @@ jobDefaults:
 
   # ArgoCD hook configuration
   argocd:
-    hook: PreSync
+    hook: Sync
     syncWave: "1"
     hookDeletePolicy: BeforeHookCreation
 
@@ -67,8 +67,10 @@ jobDefaults:
   volumeMounts: []
 
   # RBAC defaults
+  # inform serviceAccountName to use an existing SA
+  serviceAccountName: ""
   serviceAccount:
-    create: true
+    create: false
     annotations: {}
   rbac:
     create: false
@@ -129,8 +131,10 @@ jobs: {}
   #     limits:
   #       cpu: "1"
   #       memory: 512Mi
+  #   # inform serviceAccountName to use an existing SA
+  #   serviceAccountName: ""
   #   serviceAccount:
-  #     create: true
+  #     create: false
   #     annotations:
   #       eks.amazonaws.com/role-arn: arn:aws:iam::123456789:role/lambda-deploy
   #   rbac:


### PR DESCRIPTION
This pull request introduces improved flexibility and clarity for service account handling in the `k8s-job` Helm chart, along with updates to default values and comprehensive test coverage. The most significant changes provide explicit control over whether to create a new Kubernetes service account or use an existing one for each job, and ensure these behaviors are well-documented and tested.

**Service Account Handling Improvements:**

- Added support for specifying `serviceAccountName` at both the job and default levels, allowing jobs to use an existing Kubernetes service account if desired. (`charts/k8s-job/templates/_helpers.tpl`, `charts/k8s-job/values.yaml`) [[1]](diffhunk://#diff-e1d3fb59a4f2566b21c0a80e0a12a98dd9a559ace782b41c157f8a8530847451R124-R126) [[2]](diffhunk://#diff-3bf0458284b50ac72275dee75afa0c5e2a011bffdda12e4336970753306ebc47R70-R73) [[3]](diffhunk://#diff-3bf0458284b50ac72275dee75afa0c5e2a011bffdda12e4336970753306ebc47R134-R137)
- Changed the default for `serviceAccount.create` to `false`, so service accounts are only created when explicitly requested. (`charts/k8s-job/values.yaml`) [[1]](diffhunk://#diff-3bf0458284b50ac72275dee75afa0c5e2a011bffdda12e4336970753306ebc47R70-R73) [[2]](diffhunk://#diff-3bf0458284b50ac72275dee75afa0c5e2a011bffdda12e4336970753306ebc47R134-R137)
- Updated job template logic to prioritize `serviceAccount.create` over `serviceAccountName`, and to omit `serviceAccountName` entirely if neither is set. (`charts/k8s-job/templates/job.yaml`)

**Testing Enhancements:**

- Added and updated tests to ensure correct rendering and prioritization of service account settings, including scenarios for default, per-job, and override behaviors. (`charts/k8s-job/tests/job_test.yaml`, `charts/k8s-job/tests/serviceaccount_test.yaml`) [[1]](diffhunk://#diff-746714cfb0ad87507a9b9ab0774d27cb338f4adbf558c60a5258cf46422eb918R452-R539) [[2]](diffhunk://#diff-8b3c636061ad8a023fd318a7601de6b63751d2dcbf14a33b1c854c0aa5c71f52L30-R49) [[3]](diffhunk://#diff-8b3c636061ad8a023fd318a7601de6b63751d2dcbf14a33b1c854c0aa5c71f52R65-R66) [[4]](diffhunk://#diff-8b3c636061ad8a023fd318a7601de6b63751d2dcbf14a33b1c854c0aa5c71f52R82-R83) [[5]](diffhunk://#diff-8b3c636061ad8a023fd318a7601de6b63751d2dcbf14a33b1c854c0aa5c71f52R100) [[6]](diffhunk://#diff-8b3c636061ad8a023fd318a7601de6b63751d2dcbf14a33b1c854c0aa5c71f52R115-R122) [[7]](diffhunk://#diff-8b3c636061ad8a023fd318a7601de6b63751d2dcbf14a33b1c854c0aa5c71f52R136-R137)

**Default Value Updates:**

- Updated the default container image tag from `20-alpine` to `24-alpine` for jobs. (`charts/k8s-job/values.yaml`)
- Changed the default ArgoCD hook from `PreSync` to `Sync`. (`charts/k8s-job/values.yaml`)

**Chart Versioning:**

- Bumped the chart version to `0.3.0` to reflect these breaking and feature changes. (`charts/k8s-job/Chart.yaml`)